### PR TITLE
Airflow SFTPToGCSOperator sftp file exist check

### DIFF
--- a/airflow/providers/google/cloud/transfers/sftp_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/sftp_to_gcs.py
@@ -71,6 +71,7 @@ class SFTPToGCSOperator(BaseOperator):
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
     :param sftp_prefetch: Whether to enable SFTP prefetch, the default is True.
+    :param fail_on_sftp_file_not_exist: Whether to fail the task if file do not exit in SFTP server, the default is True.
     """
 
     template_fields: Sequence[str] = (
@@ -93,6 +94,7 @@ class SFTPToGCSOperator(BaseOperator):
         move_object: bool = False,
         impersonation_chain: str | Sequence[str] | None = None,
         sftp_prefetch: bool = True,
+        fail_on_sftp_file_not_exist: bool = True,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -107,6 +109,7 @@ class SFTPToGCSOperator(BaseOperator):
         self.move_object = move_object
         self.impersonation_chain = impersonation_chain
         self.sftp_prefetch = sftp_prefetch
+        self.fail_on_sftp_file_not_exist=fail_on_sftp_file_not_exist
 
     def execute(self, context: Context):
         self.destination_path = self._set_destination_path(self.destination_path)
@@ -156,18 +159,27 @@ class SFTPToGCSOperator(BaseOperator):
             destination_object,
         )
 
+        file_existence=True
         with NamedTemporaryFile("w") as tmp:
-            sftp_hook.retrieve_file(source_path, tmp.name, prefetch=self.sftp_prefetch)
+            try:
+                self.log.info("trying to retrieve file %s", source_path)
+                sftp_hook.retrieve_file(source_path, tmp.name, prefetch=self.sftp_prefetch)
+            except FileNotFoundError:
+                if not self.fail_on_sftp_file_not_exist:
+                    self.log.info("File %s does not exist in SFTP server", source_path)
+                    file_existence=False
+                else:
+                    raise FileNotFoundError
+            if file_existence:
+                gcs_hook.upload(
+                    bucket_name=self.destination_bucket,
+                    object_name=destination_object,
+                    filename=tmp.name,
+                    mime_type=self.mime_type,
+                    gzip=self.gzip,
+                )
 
-            gcs_hook.upload(
-                bucket_name=self.destination_bucket,
-                object_name=destination_object,
-                filename=tmp.name,
-                mime_type=self.mime_type,
-                gzip=self.gzip,
-            )
-
-        if self.move_object:
+        if self.move_object and file_existence:
             self.log.info("Executing delete of %s", source_path)
             sftp_hook.delete_file(source_path)
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



Adds a **fail_on_sftp_file_not_exist** parameter to the `SFTPToGCSOperator`, allowing users to configure whether the task should fail or continue when the specified file is not found on the SFTP server.

---

### Description

This PR introduces a new parameter, `fail_on_sftp_file_not_exist`, to the `SFTPToGCSOperator`. This parameter allows users to specify whether the operator should fail the task if the specified file is not found on the SFTP server.

Previously, the operator would raise an exception and fail the task if the file was not found on the SFTP server. With the introduction of the `fail_on_sftp_file_not_exist` parameter, users now have the flexibility to configure the operator's behavior in such scenarios. By setting this parameter to `False`, the operator will log a warning message instead of failing the task, allowing the DAG to continue running.

This enhancement aligns with similar improvements requested for other operators, such as the `SFTPToS3Operator`.

### Changes

- Added the `fail_on_sftp_file_not_exist` parameter to the `SFTPToGCSOperator`.
- Updated the `_copy_single_object` method to conditionally handle missing files based on the value of `fail_on_sftp_file_not_exist`.
- Provided relevant test cases to ensure the new parameter functions as expected.

